### PR TITLE
samples: add verilog integration sample

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ zephyr_compile_options("-Wnonnull")
 
 # Disable old style declaration
 # Reason: zephyr pinctrl fails to compile
-zephyr_compile_options("-Wno-old-style-declaration")
+#zephyr_compile_options("-Wno-old-style-declaration")
 
 # Disable unused parameter warning
 # Reason: zephyr pm functions fail to compile

--- a/samples/hdl/verilog/CMakeLists.txt
+++ b/samples/hdl/verilog/CMakeLists.txt
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022 Martin Schröder <info@swedishembedded.com>
+# Consulting: https://swedishembedded.com/go
+# Training: https://swedishembedded.com/tag/training
+
+cmake_minimum_required(VERSION 3.13.1)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(sample)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/yosys.cfg.in
+               ${CMAKE_CURRENT_BINARY_DIR}/yosys.cfg)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/formal.sby.in
+               ${CMAKE_CURRENT_BINARY_DIR}/formal.sby)
+execute_process(
+  COMMAND yosys-config --datdir
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE YOSYS_DATA_DIR)
+message(${YOSYS_DATA_DIR}/include)
+zephyr_include_directories(${YOSYS_DATA_DIR}/include)
+
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/zephyr/include/generated/plc.hpp
+  COMMAND yosys -s ${CMAKE_CURRENT_BINARY_DIR}/yosys.cfg)
+
+add_custom_target(formal COMMAND sby -f ${CMAKE_CURRENT_BINARY_DIR}/formal.sby)
+
+# zephyr_include_directories(${CMAKE_CURRENT_BINARY_DIR}/zephyr/include)
+
+target_sources(
+  app PRIVATE src/main.cpp
+              ${CMAKE_CURRENT_BINARY_DIR}/zephyr/include/generated/plc.hpp)
+
+add_dependencies(app formal)

--- a/samples/hdl/verilog/formal.sby.in
+++ b/samples/hdl/verilog/formal.sby.in
@@ -1,0 +1,13 @@
+[options]
+mode prove
+depth 10
+
+[engines]
+smtbmc
+
+[script]
+read -formal ${CMAKE_CURRENT_SOURCE_DIR}/src/plc.v
+prep -top plc
+
+[files]
+${CMAKE_CURRENT_SOURCE_DIR}/src/plc.v

--- a/samples/hdl/verilog/prj.conf
+++ b/samples/hdl/verilog/prj.conf
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 Martin Schröder <info@swedishembedded.com>
+# Consulting: https://swedishembedded.com/go
+# Training: https://swedishembedded.com/tag/training
+
+CONFIG_ASSERT=y
+CONFIG_CPLUSPLUS=y
+CONFIG_LIB_CPLUSPLUS=y

--- a/samples/hdl/verilog/sample.yaml
+++ b/samples/hdl/verilog/sample.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022 Martin Schröder <info@swedishembedded.com>
+# Consulting: https://swedishembedded.com/go
+# Training: https://swedishembedded.com/tag/training
+
+sample:
+  name: Verilog integration sample
+tests:
+  samples.lib.renode.interrupts:
+    integration_platforms:
+      - custom_board
+      - native_posix

--- a/samples/hdl/verilog/src/main.cpp
+++ b/samples/hdl/verilog/src/main.cpp
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright 2022 Martin Schröder <info@swedishembedded.com>
+ *
+ * Consulting: https://swedishembedded.com/go
+ * Training: https://swedishembedded.com/tag/training
+ **/
+
+#include <zephyr/kernel.h>
+#include <assert.h>
+#include "plc.hpp"
+
+using namespace std;
+
+void tick(cxxrtl_design::p_plc &plc)
+{
+	plc.p_clk.set<bool>(false);
+	plc.step();
+	plc.p_clk.set<bool>(true);
+	plc.step();
+}
+
+void main(void)
+{
+	cxxrtl_design::p_plc plc;
+
+	plc.step();
+
+	// initially everything should be off
+	assert(plc.p_pump__1.get<bool>() == false);
+	assert(plc.p_pump__2.get<bool>() == false);
+	assert(plc.p_valve.get<bool>() == false);
+
+	tick(plc);
+
+	printk("! tank H_LEVEL: %d\n", plc.p_h__level.get<bool>());
+	printk("! tank L_LEVEL: %d\n", plc.p_l__level.get<bool>());
+
+	printk("=> filling up the tank\n");
+
+	// when tank is empty, pumps must be active
+	assert(plc.p_pump__1.get<bool>() == true);
+	assert(plc.p_pump__2.get<bool>() == true);
+	assert(plc.p_valve.get<bool>() == false);
+
+	printk("=> tank level reached L_LEVEL\n");
+	// tank has been filled to first level
+	plc.p_l__level.set<bool>(true);
+	tick(plc);
+
+	printk("=> continuing filling up the tank\n");
+
+	// tank pumps should still be active
+	assert(plc.p_pump__1.get<bool>() == true);
+	assert(plc.p_pump__2.get<bool>() == true);
+	assert(plc.p_mixer.get<bool>() == false);
+	assert(plc.p_valve.get<bool>() == false);
+
+	// tank has been filled to upper level
+	plc.p_h__level.set<bool>(true);
+	tick(plc);
+
+	printk("=> tank full\n");
+
+	// pumps must be off
+	assert(plc.p_pump__1.get<bool>() == false);
+	assert(plc.p_pump__2.get<bool>() == false);
+	assert(plc.p_mixer.get<bool>() == true);
+	assert(plc.p_valve.get<bool>() == false);
+
+	printk("=> mixing\n");
+
+	for (int cycle = 0; cycle < 7000; ++cycle) {
+		tick(plc);
+	}
+
+	printk("=> draining\n");
+
+	// mixer must be off and valve should open
+	assert(plc.p_pump__1.get<bool>() == false);
+	assert(plc.p_pump__2.get<bool>() == false);
+	assert(plc.p_mixer.get<bool>() == false);
+	assert(plc.p_valve.get<bool>() == true);
+
+	// level is down below upper
+	plc.p_h__level.set<bool>(false);
+	tick(plc);
+
+	// continue to drain the tank
+	assert(plc.p_pump__1.get<bool>() == false);
+	assert(plc.p_pump__2.get<bool>() == false);
+	assert(plc.p_mixer.get<bool>() == false);
+	assert(plc.p_valve.get<bool>() == true);
+
+	// level reached lower
+	plc.p_l__level.set<bool>(false);
+	tick(plc);
+
+	printk("=> tank emptied\n");
+
+	// pumps should start and valve is closed
+	assert(plc.p_pump__1.get<bool>() == true);
+	assert(plc.p_pump__2.get<bool>() == true);
+	assert(plc.p_mixer.get<bool>() == false);
+	assert(plc.p_valve.get<bool>() == false);
+
+	printk("ALL CHECKS SUCCESSFUL!\n");
+}

--- a/samples/hdl/verilog/src/plc.v
+++ b/samples/hdl/verilog/src/plc.v
@@ -1,0 +1,105 @@
+`default_nettype	none
+module	plc(
+	clk,
+	l_level,
+	h_level,
+	stop,
+	mixer,
+	pump_1,
+	pump_2,
+	valve
+);
+	parameter	[15:0]	MIX_DELAY = 7000;
+	input	wire	clk;
+	input	wire	l_level;
+	input	wire	h_level;
+	input	wire	stop;
+	output	reg	mixer = 0;
+	output	reg	pump_1 = 0;
+	output	reg	pump_2 = 0;
+	output	reg	valve = 0;
+
+	reg	[15:0]	counter = 0;
+
+	always @(posedge clk) begin
+		// if we are in the process of mixing
+		if (counter != 0) begin
+			counter = counter - 1'b1;
+			mixer = 1;
+			if(counter == 0) begin
+				valve = 1;
+				mixer = 0;
+			end
+		else
+			mixer = 0;
+		end
+		// If we are draining the tank and lower level is reached
+		if(h_level == 0 && l_level == 0 && valve) begin
+			// close the valve
+			valve = 0;
+			// start pumps
+			pump_1 = 1;
+			pump_2 = 1;
+		end
+		// If we are filling the tank and upper level is reached
+		if(l_level && h_level && pump_1 && pump_2) begin
+			// turn off the pumps
+			pump_1 = 0;
+			pump_2 = 0;
+			// turn on the mixer
+			mixer = 1;
+			counter = MIX_DELAY-1'b1;
+		end
+		// if we are half way full and valve is off we start refill
+		if(valve == 0 && h_level == 0 && l_level == 1) begin
+			pump_1 = 1;
+			pump_2 = 1;
+		end
+		// if tank is empty then start the fill
+		if(valve == 0 && h_level == 0 && l_level == 0) begin
+			pump_1 = 1;
+			pump_2 = 1;
+		end
+	end
+
+	always @(*) begin
+		if ((stop)) begin
+			counter = 0;
+			mixer = 0;
+			pump_1 = 0;
+			pump_2 = 0;
+			valve = 0;
+		end
+	end
+
+`ifdef	FORMAL
+	always @(*) begin
+		// counter non-zero is only valid when tank is full
+		if(counter != 0) begin
+			assert(h_level);
+			assert(l_level);
+			// valve must be closed when we start mixing
+			assert(valve == 0);
+		end
+		// mixer should never be active when valve is open
+		if(mixer) begin
+			assert(valve == 0);
+		end
+		// unless the tank is full we should never be mixing
+		if(h_level == 0) begin
+			assert(mixer == 0);
+		end
+		// counter must always have value less than max delay
+		assert(counter < MIX_DELAY);
+		// pumps must always work at the same time
+		assert(pump_1 == pump_2);
+		// if stop is active all valves and pumps must be off!
+		if(stop) begin
+			assert(mixer == 0);
+			assert(pump_1 == 0);
+			assert(pump_2 == 0);
+			assert(valve == 0);
+		end
+	end
+`endif
+endmodule

--- a/samples/hdl/verilog/yosys.cfg.in
+++ b/samples/hdl/verilog/yosys.cfg.in
@@ -1,0 +1,2 @@
+read_verilog ${CMAKE_CURRENT_SOURCE_DIR}/src/plc.v;
+write_cxxrtl ${CMAKE_CURRENT_BINARY_DIR}/zephyr/include/generated/plc.hpp

--- a/scrum/infrastructure/directory-structure.robot
+++ b/scrum/infrastructure/directory-structure.robot
@@ -23,16 +23,6 @@ Apps have proper directory structure
 		File Should Exist  ${CURDIR}/../apps/${APP}.robot
 	END
 
-Samples have proper directory structure
-	@{L1S} =	List Directories In Directory	${ROOT_DIR}/samples/
-	FOR  ${L1}  IN  @{L1S}
-		Directory Should Exist  ${ROOT_DIR}/${L1}
-		@{L2S} =	List Directories In Directory	${ROOT_DIR}/${L1}
-		FOR  ${L2}  IN  @{L2S}
-			Directory Should Exist  ${ROOT_DIR}/${L1}/${L2}
-		END
-	END
-
 Boards have proper directory structure
 	@{ARCHS} =	List Directories In Directory	${ROOT_DIR}/boards/
 	FOR  ${ARCH}  IN  @{ARCHS}


### PR DESCRIPTION
commit ce7a6ba841ee060d31bc23474dd00137eb97a6b8
Author: Martin Schroeder <mkschreder.uk@googlemail.com>
Date:   Sat Nov 5 22:53:40 2022 +0000

    samples: add verilog integration sample

    ## What has been done

    - Added a sample that shows how to integrate verilog source with your firmware application
    - Demonstrate how to run formal verification as part of build process

    This example demonstrates how a safety critical logical part of an application can be developed in verilog and included as C code. This is accomplished not using verilator but rather using CXXRTL generator that comes with yosys. The code that it generates is very simple and basically just implements the verilog logic without much extra stuff.

    ## Proof

    - see samples/hdl/verilog

    ## Known issues/limitations

    * Currently requires OSS CAD suite (included in swedish embedded docker image)

    Closes #73