### PR TITLE
integrity: drivers: make tests check more flexible

### DIFF
--- a/integrity/infrastructure/DirectoryStructure.robot
+++ b/integrity/infrastructure/DirectoryStructure.robot
@@ -70,19 +70,6 @@ Directory has drivers structure ${driversbase}
 	FOR  ${DRIVER_TYPE}  IN  @{DRIVER_TYPES}
 		File Should Exist  ${driversbase}/${DRIVER_TYPE}/CMakeLists.txt
 		File Should Exist  ${driversbase}/${DRIVER_TYPE}/Kconfig
-		@{DRIVERS} =	List Files In Directory	${driversbase}/${DRIVER_TYPE}/  *.c
-		FOR  ${DRIVER}  IN  @{DRIVERS}
-			# make sure there is a test for each driver
-			${PATH}  ${FILE} =  Split Path  ${DRIVER}
-			${NAME}  ${EXT} =  Split Extension  ${FILE}
-			Directory Should Exist  ${ROOT_DIR}/tests/drivers/${DRIVER_TYPE}/${NAME}/
-			# make sure driver C file is included
-			${STR}    Get File    ${ROOT_DIR}/tests/drivers/${DRIVER_TYPE}/${NAME}/CMakeLists.txt
-			Should Contain    ${STR}    ${NAME}.c
-			# check if unit test includes the file
-			${STR}    Get File    ${ROOT_DIR}/tests/drivers/${DRIVER_TYPE}/${NAME}/src/unit.c
-			Should Contain    ${STR}    ${NAME}.c
-		END
 	END
 
 Directory has lib structure ${dir}

--- a/integrity/infrastructure/Testing.robot
+++ b/integrity/infrastructure/Testing.robot
@@ -9,28 +9,56 @@ Library  testing.py
 
 *** Variables ***
 ${ROOT_DIR}  ${CURDIR}/../../
+${TESTS_DIR}  ${ROOT_DIR}/tests/
 
 *** Keywords ***
 
+Source file should have integration test ${SOURCE}
+	# make sure there is a test for each driver
+	${PATH}  ${FILE} =  Split Path  ${SOURCE}
+	${NAME}  ${EXT} =  Split Extension  ${FILE}
+
+	Directory Should Exist  ${TESTS_DIR}/${NAME}/
+
+	# Integration tests currently include the file
+	${STR}    Get File    ${TESTS_DIR}/${NAME}/CMakeLists.txt
+	Should Contain    ${STR}    ${NAME}.c
+
+	# Check that name follows a good pattern
+	${STR}    Get File    ${TESTS_DIR}/${NAME}/testcase.yaml
+	Should Contain    ${STR}    ${NAME}.integration
+	# Quick check for tag (could be done by parsing python)
+	Should Contain    ${STR}    ${NAME}.c
+
+Source file should have unit test ${SOURCE}
+	# make sure there is a test for each driver
+	${PATH}  ${FILE} =  Split Path  ${SOURCE}
+	${NAME}  ${EXT} =  Split Extension  ${FILE}
+
+	Directory Should Exist  ${TESTS_DIR}/${NAME}/
+
+	# The main C file must be in the cmake file
+	${STR}    Get File    ${TESTS_DIR}/${NAME}/src/unit.c
+	Should Contain    ${STR}    ${NAME}.c
+
+	# Check that name follows a good pattern
+	${STR}    Get File    ${TESTS_DIR}/${NAME}/testcase.yaml
+	Should Contain    ${STR}    ${NAME}.unit
+	# Quick check for tag (could be done by parsing python)
+	Should Contain    ${STR}    ${NAME}.c
+
 Sources under ${dir} have unit tests under ${testbase}
+	Set Test Variable  ${TESTS_DIR}  ${testbase}
+
 	@{SOURCES} =	List Files In Directory	${dir}/  *.c
 	FOR  ${SOURCE}  IN  @{SOURCES}
-		# make sure there is a test for each driver
-		${PATH}  ${FILE} =  Split Path  ${SOURCE}
-		${NAME}  ${EXT} =  Split Extension  ${FILE}
-		# The test directory should exist
-		Directory Should Exist  ${testbase}/${NAME}/
-		#${STR}    Get File    ${testbase}/${NAME}/CMakeLists.txt
-		#Should Contain    ${STR}    ${NAME}.c
-		# The main C file must be in the cmake file
-		${STR}    Get File    ${testbase}/${NAME}/src/unit.c
-		Should Contain    ${STR}    ${NAME}.c
-		# Unit test must not have logging enabled (bad for coverage)
-		${STR}    Get File    ${testbase}/${NAME}/prj.conf
-		Should Contain    ${STR}    CONFIG_TEST_LOGGING_DEFAULTS=n
-		# Check that name follows a good pattern
-		${STR}    Get File    ${testbase}/${NAME}/testcase.yaml
-		Should Contain    ${STR}    ${NAME}.unit
-		# This will match tag
-		Should Contain    ${STR}    ${NAME}.c
+		Source file should have unit test ${SOURCE}
+	END
+
+Sources under ${dir} have integration tests under ${testbase}
+	Set Test Variable  ${TESTS_DIR}  ${testbase}
+
+	@{SOURCES} =	List Files In Directory	${dir}/  *.c
+	FOR  ${SOURCE}  IN  @{SOURCES}
+		Source file should have integration test ${SOURCE}
 	END

--- a/integrity/infrastructure/directory-structure.robot
+++ b/integrity/infrastructure/directory-structure.robot
@@ -8,6 +8,7 @@ Library  OperatingSystem
 Library  Process
 Library  directory-structure.py
 Resource  ${CURDIR}/DirectoryStructure.robot
+Resource  ${CURDIR}/Testing.robot
 
 *** Variables ***
 ${ROOT_DIR}  ${CURDIR}/../../
@@ -33,6 +34,12 @@ Drivers have proper directory structure
         FOR    ${DRIVER}    IN    @{DRIVERS}
             ${PATH}    ${FILE} =    Split Path    ${DRIVER}
             ${NAME}    ${EXT} =    Split Extension    ${FILE}
+
+			Set Test Variable  ${TESTS_DIR}  ${ROOT_DIR}/tests/drivers/${DRIVER_TYPE}/
+
+			# Drivers are required to have unit and integration tests
+			Source file should have unit test ${driverbase}/${DRIVER_TYPE}/${DRIVER}
+			Source file should have integration test ${driverbase}/${DRIVER_TYPE}/${DRIVER}
 
 			# make sure there is integrity check for driver
 			File Should Exist  ${INTEGRITY_DIR}/drivers/${DRIVER_TYPE}/${NAME}.robot


### PR DESCRIPTION
- It is now possible to define custom directory tree integrity checks that only require unit or only integration tests

Closes #18

Signed-off-by: Martin Schröder <info@swedishembedded.com>